### PR TITLE
Cleanup warnings and deprecations ahead of 2026.7 for BT Proxy only and Zigbee+BT Proxy configurations

### DIFF
--- a/configs/bt.yaml
+++ b/configs/bt.yaml
@@ -146,7 +146,7 @@ switch:
 
 ## Mode LAN/USB switch
   - platform: gpio
-    name: "DEVICE MODE SWITCH (LAN|OFF / USB|ON)"
+    name: "DEVICE MODE SWITCH (LAN|OFF - USB|ON)"
     restore_mode: ALWAYS_OFF
     icon: mdi:toggle-switch
     internal: true

--- a/configs/bt.yaml
+++ b/configs/bt.yaml
@@ -64,7 +64,9 @@ ethernet:
   mdc_pin: GPIO23
   mdio_pin: GPIO18
   clk:
-    pin: GPIO0
+    pin:
+      number: GPIO0
+      ignore_strapping_warning: true
     mode: CLK_EXT_IN
   phy_addr: 1
   power_pin: GPIO16
@@ -163,6 +165,7 @@ switch:
     id: gpio12LED1
     pin:
       number: GPIO12
+      ignore_strapping_warning: true
 
   - platform: gpio
     name: "LED - power (Yellow)"

--- a/configs/zb-bt.yaml
+++ b/configs/zb-bt.yaml
@@ -69,7 +69,9 @@ ethernet:
   mdc_pin: GPIO23
   mdio_pin: GPIO18
   clk:
-    pin: GPIO0
+    pin:
+      number: GPIO0
+      ignore_strapping_warning: true
     mode: CLK_EXT_IN
   phy_addr: 1
   power_pin: GPIO16
@@ -77,7 +79,9 @@ ethernet:
 ## UART Settings
 uart:
   id: uart_bus
-  rx_pin: GPIO5
+  rx_pin:
+    number: GPIO5
+    ignore_strapping_warning: true
   tx_pin: GPIO17
   baud_rate: 115200
 
@@ -254,6 +258,7 @@ switch:
     id: gpio12LED1
     pin:
       number: GPIO12
+      ignore_strapping_warning: true
 
   - platform: gpio
     name: "LED - power (Yellow)"

--- a/configs/zb-bt.yaml
+++ b/configs/zb-bt.yaml
@@ -222,7 +222,7 @@ switch:
 
 ## Mode LAN/USB switch
   - platform: template
-    name: "DEVICE MODE SWITCH (LAN|OFF / USB|ON)"
+    name: "DEVICE MODE SWITCH (LAN|OFF - USB|ON)"
     id: modeSwitchTemplate
     turn_on_action:
       - switch.turn_on: gpio12LED1
@@ -238,7 +238,7 @@ switch:
           state: OFF
 
   - platform: gpio
-    name: "DEVICE MODE SWITCH (LAN|OFF / USB|ON)"
+    name: "DEVICE MODE SWITCH (LAN|OFF - USB|ON)"
     restore_mode: ALWAYS_OFF
     icon: mdi:toggle-switch
     internal: true


### PR DESCRIPTION
PR #16 only implemented the fix for Thread+BT Proxy config (`th-bt.yaml`)

This PR also implement similar fixes for BT Proxy only (`bt.yaml`) and Zigbee+BT Proxy (`zb-bt.yaml`) configuration

I've tested the Zigbee+BT Proxy config on my SLZB-06.